### PR TITLE
Update 'top downloaded' and 'top starred' calculations to only consider active addons

### DIFF
--- a/app/models/addon.rb
+++ b/app/models/addon.rb
@@ -72,4 +72,8 @@ class Addon < ActiveRecord::Base
     return false unless github_stats.penultimate_commit_date
     github_stats.penultimate_commit_date > 3.months.ago
   end
+
+  def self.active
+    where('(hidden is null or hidden != true) and (is_wip is null or is_wip != true)')
+  end
 end


### PR DESCRIPTION
This removes hidden and WIP addons from the count used to determine whether an addon is in the top 10% for NPM downloads/Github stars. This should reduce the number of addons that get these points but should give a more accurate sense of what's actually popular.
