### PR TITLE
Handle missing 'github' key in NPM response

### DIFF
--- a/app/workers/addon_data_updater.rb
+++ b/app/workers/addon_data_updater.rb
@@ -89,6 +89,9 @@ class AddonDataUpdater
         addon_props[:github_user] = Regexp.last_match(1)
         addon_props[:github_repo] = Regexp.last_match(2)
       end
+    elsif repo_url =~ %r{^https*://www\.github\.com/(.+?)/(.+?)}
+      addon_props[:github_user] = Regexp.last_match(1)
+      addon_props[:github_repo] = Regexp.last_match(2)
     end
     @addon.update!(addon_props)
   end


### PR DESCRIPTION
If the response from NPM for an addon doesn't include a `github` section but has a Github URL, extract the username/repo from the URL and set them on the addon, so that we can fetch Github data for that addon.