### PR TITLE
Add indexes on package and package/version columns in addon_version_dependencies

### DIFF
--- a/app/models/addon_version_dependency.rb
+++ b/app/models/addon_version_dependency.rb
@@ -12,7 +12,9 @@
 #
 # Indexes
 #
-#  index_addon_version_dependencies_on_addon_version_id  (addon_version_id)
+#  index_addon_version_dependencies_on_addon_version_id     (addon_version_id)
+#  index_addon_version_dependencies_on_package              (package)
+#  index_addon_version_dependencies_on_package_and_version  (package,version)
 #
 
 class AddonVersionDependency < ApplicationRecord

--- a/db/migrate/20180314180351_add_indexes_on_addon_version_dependencies.rb
+++ b/db/migrate/20180314180351_add_indexes_on_addon_version_dependencies.rb
@@ -1,0 +1,8 @@
+class AddIndexesOnAddonVersionDependencies < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :addon_version_dependencies, :package, algorithm: :concurrently
+    add_index :addon_version_dependencies, [:package, :version], algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180213164540) do
+ActiveRecord::Schema.define(version: 20180314180351) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -57,6 +57,8 @@ ActiveRecord::Schema.define(version: 20180213164540) do
     t.string "dependency_type"
     t.integer "addon_version_id"
     t.index ["addon_version_id"], name: "index_addon_version_dependencies_on_addon_version_id"
+    t.index ["package", "version"], name: "index_addon_version_dependencies_on_package_and_version"
+    t.index ["package"], name: "index_addon_version_dependencies_on_package"
   end
 
   create_table "addon_versions", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
Create these indexes concurrently so they don't block writes, because they'll take a long time to run (~2-3 hours each on my laptop).