### PR TITLE
Add endpoint for addon version dependencies

### DIFF
--- a/app/controllers/api/v2/addon_dependencies_controller.rb
+++ b/app/controllers/api/v2/addon_dependencies_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class API::V2::AddonDependenciesController < API::V2::JsonapiBaseController
+end

--- a/app/resources/api/v2/addon_dependency_resource.rb
+++ b/app/resources/api/v2/addon_dependency_resource.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class API::V2::AddonDependencyResource < JSONAPI::Resource
+  immutable
+  model_name 'AddonVersionDependency'
+
+  attributes :package, :dependency_type
+
+  has_one :dependent_version, class_name: 'Version', relation_name: 'addon_version', foreign_key: 'addon_version_id'
+
+  filter :addons_only, apply: ->(records, value, _options) {
+    addons_only = ActiveModel::Type::Boolean.new.cast(value[0])
+    if addons_only
+      records.where('package in (select name from addons)')
+    else
+      records
+    end
+  }, default: true
+
+  filter :addon_version_id
+  filter :dependency_type
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,10 @@ Rails.application.routes.draw do
         jsonapi_related_resources :addons
       end
 
+      jsonapi_resources :addon_dependencies do
+        # This block intentionally left empty to not generate relationship routes
+      end
+
       jsonapi_resources :test_results do
         jsonapi_related_resources :version
       end


### PR DESCRIPTION
Filters out dependencies that are not addons by default - this is done with a subquery which could be improved.