### PR TITLE
Fix addon version dependency import

### DIFF
--- a/app/lib/npm_addon_data_updater.rb
+++ b/app/lib/npm_addon_data_updater.rb
@@ -121,8 +121,6 @@ class NpmAddonDataUpdater
     return unless addon_version_metadata.include?('ember-addon')
     return unless addon_version_metadata['ember-addon'].include?('versionCompatibility')
 
-    addon_version.compatible_versions.clear
-
     addon_version_metadata['ember-addon']['versionCompatibility'].each do |package_name, package_version|
       version_compatibility = AddonVersionCompatibility.find_or_create_by(
         package: package_name,
@@ -133,7 +131,6 @@ class NpmAddonDataUpdater
   end
 
   def update_addon_version_dependencies(addon_version, addon_version_metadata)
-    addon_version.all_dependencies.clear
     %w[devDependencies dependencies optionalDependencies peerDependencies].each do |dependency_type|
       next unless addon_version_metadata[dependency_type]
       addon_version_metadata[dependency_type].each do |package_name, version|
@@ -169,7 +166,6 @@ class NpmAddonDataUpdater
   end
 
   def update_keywords
-    @addon.npm_keywords.clear
     if @metadata['keywords']
       @metadata['keywords'].each do |keyword|
         npm_keyword = NpmKeyword.find_or_create_by(keyword: keyword)
@@ -183,7 +179,6 @@ class NpmAddonDataUpdater
   end
 
   def update_maintainers
-    @addon.maintainers.clear
     @metadata['maintainers'].each do |maintainer|
       npm_user = NpmMaintainer.find_or_create_by(name: maintainer['name'])
       npm_user.email = maintainer['email']


### PR DESCRIPTION
Use `.find_or_create_by` instead of just `.create` when populating AddonVersionCompatibility and (more crucially) AddonVersionDependencies. This way we don't create duplicate rows, because `.clear` on a relation didn't do what I thought it did.