### PR TITLE
Stop returning `removed_from_npm` addons in autocomplete data

### DIFF
--- a/app/controllers/api/v2/autocomplete_controller.rb
+++ b/app/controllers/api/v2/autocomplete_controller.rb
@@ -3,7 +3,7 @@
 class API::V2::AutocompleteController < ApplicationController
   def data
     render json: {
-      addons: Addon.select(:id, :name, :description, :score, :is_wip).where(hidden: :false),
+      addons: Addon.not_hidden.select(:id, :name, :description, :score, :is_wip),
       categories: Category.select(:id, :name),
       maintainers: NpmMaintainer.select(:id, :name)
     }.as_json

--- a/test/controllers/api/v2/autocomplete_controller_test.rb
+++ b/test/controllers/api/v2/autocomplete_controller_test.rb
@@ -3,7 +3,32 @@
 require 'test_helper'
 
 class API::V2::AutocompleteControllerTest < ActionController::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test 'hidden addons are not included' do
+    create :addon
+    hidden_addon = create(:addon, :hidden)
+
+    assert_not_includes autocomplete_addon_names, hidden_addon.name
+  end
+
+  test 'addons that are removed_from_npm are not included' do
+    create :addon
+    removed_addon = create(:addon, removed_from_npm: true)
+
+    assert_not_includes autocomplete_addon_names, removed_addon.name
+  end
+
+  test 'addons that are WIP are included' do
+    create :addon
+    wip_addon = create(:addon, is_wip: true)
+
+    assert_includes autocomplete_addon_names, wip_addon.name
+  end
+
+  private
+
+  def autocomplete_addon_names
+    get :data
+
+    JSON.parse(response.body)['addons'].map { |a| a['name'] }
+  end
 end


### PR DESCRIPTION
Fixes #57. Changes the autocomplete data controller method to use `Addon.not_hidden` instead of `Addon.where(hidden: false)` to ensure that other addons we shouldn't display won't appear in the autocomplete data.