### PR TITLE
Addon version dependency resource filters out hidden addons by default

### DIFF
--- a/app/resources/api/v2/addon_dependency_resource.rb
+++ b/app/resources/api/v2/addon_dependency_resource.rb
@@ -8,10 +8,10 @@ class API::V2::AddonDependencyResource < JSONAPI::Resource
 
   has_one :dependent_version, class_name: 'Version', relation_name: 'addon_version', foreign_key: 'addon_version_id'
 
-  filter :addons_only, apply: ->(records, value, _options) {
+  filter :visible_addons_only, apply: ->(records, value, _options) {
     addons_only = ActiveModel::Type::Boolean.new.cast(value[0])
     if addons_only
-      records.where('package_addon_id is not null')
+      records.joins(:package_addon).merge(Addon.not_hidden)
     else
       records
     end

--- a/test/integration/api/v2/addon_dependency_test.rb
+++ b/test/integration/api/v2/addon_dependency_test.rb
@@ -37,11 +37,26 @@ class API::V2::AddonDependencyTest < IntegrationTest
     assert_equal addon_dependency.id.to_s, parsed_response['data'][0]['id']
   end
 
+  test 'hidden addon dependencies are not returned' do
+    addon_dependency = create :addon_version_dependency, :is_addon
+    addon_dependency.package_addon.update(hidden: false)
+
+    hidden_addon_dependency = create :addon_version_dependency, :is_addon
+    hidden_addon_dependency.package_addon.update(hidden: true)
+
+    get '/api/v2/addon-dependencies'
+
+    parsed_response = json_response
+    assert_equal 1, parsed_response['data'].length, 'Only unhidden addon dependency is returned'
+
+    assert_equal addon_dependency.id.to_s, parsed_response['data'][0]['id']
+  end
+
   test 'end user can fetch non-addon addon dependencies' do
     addon_dependency = create :addon_version_dependency, :is_addon
     non_addon_addon_dependency = create :addon_version_dependency, :is_not_addon
 
-    get '/api/v2/addon-dependencies', params: { filter: { addons_only: false } }
+    get '/api/v2/addon-dependencies', params: { filter: { visible_addons_only: false } }
 
     parsed_response = json_response
     assert_equal 2, parsed_response['data'].length, 'Both addon dependencies are returned'


### PR DESCRIPTION
Noticed after our conversation about filtering out hidden addons from the dependents list that the dependencies list has the same issue.

Before fix:

http://recordit.co/A5tvZNEL77

After fix:

http://recordit.co/13j007hHP5

Changes:

 - Use inner join rather than filtering by non-null addon id in where clause (has the same effect) and additionally filter rows to addons that are not hidden

 - Update filter name to match behavior