### PR TITLE
Add ability to fetch addon dependents

### DIFF
--- a/app/resources/api/v2/addon_dependency_resource.rb
+++ b/app/resources/api/v2/addon_dependency_resource.rb
@@ -19,4 +19,11 @@ class API::V2::AddonDependencyResource < JSONAPI::Resource
 
   filter :addon_version_id
   filter :dependency_type
+
+  filter :package_addon_id, apply: ->(records, value, _options) {
+    package_addon_id = value[0]
+    latest_versions_sql = Addon.not_hidden.where('latest_addon_version_id is not null').select('latest_addon_version_id as id, name as addon_name').to_sql
+    records.where(package_addon_id: package_addon_id)
+           .joins("inner join (#{latest_versions_sql}) as latest_versions on latest_versions.id = addon_version_id")
+  }
 end

--- a/app/resources/api/v2/version_resource.rb
+++ b/app/resources/api/v2/version_resource.rb
@@ -4,7 +4,7 @@ class API::V2::VersionResource < JSONAPI::Resource
   immutable
   model_name 'AddonVersion'
 
-  attributes :version, :released, :ember_cli_version
+  attributes :version, :released, :ember_cli_version, :addon_name
   has_many :test_results
   has_one :addon
 end


### PR DESCRIPTION
 - package_addon_id filter returns addon version dependencies where the latest version of an addon has a dependency on the given addon

 - Expose addon_name attribute on version to simplify showing data on frontend