### PR TITLE
Handle JSON-formatted data from test runner

### DIFF
--- a/app/controllers/test_results_controller.rb
+++ b/app/controllers/test_results_controller.rb
@@ -77,7 +77,7 @@ class TestResultsController < ApplicationController
   end
 
   def output
-    if params[:format] == 'json'
+    if output_format == 'json'
       params[:output]
     else
       params[:output]&.read
@@ -85,7 +85,7 @@ class TestResultsController < ApplicationController
   end
 
   def output_format
-    params[:format] || 'text'
+    params[:format].blank? ? 'text' : params[:format].to_s
   end
 
   def succeeded?

--- a/app/controllers/test_results_controller.rb
+++ b/app/controllers/test_results_controller.rb
@@ -93,6 +93,7 @@ class TestResultsController < ApplicationController
   end
 
   def verify_test_results(results_str)
+    return false unless results_str
     begin
       @results = JSON.parse(results_str)
     rescue JSON::ParserError

--- a/app/controllers/test_results_controller.rb
+++ b/app/controllers/test_results_controller.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-VALID_FORMATS = %w(json text)
-
 class TestResultsController < ApplicationController
   before_action :authenticate_server, only: [:create]
   before_action :authenticate_user, only: [:retry]
@@ -48,7 +46,7 @@ class TestResultsController < ApplicationController
         output_format: output_format,
         semver_string: semver_string,
         status_message: params[:status_message],
-        succeeded: succeeded?,
+        succeeded: succeeded?
       )
 
       if succeeded?

--- a/app/models/test_result.rb
+++ b/app/models/test_result.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: test_results
@@ -27,18 +28,18 @@
 #
 
 class TestResult < ApplicationRecord
-  VALID_OUTPUT_FORMATS = %w[json text]
+  VALID_OUTPUT_FORMATS = %w[json text].freeze
 
   belongs_to :addon_version
   belongs_to :build_server
   has_many :ember_version_compatibilities
 
   validates :output_format, inclusion: { in: VALID_OUTPUT_FORMATS }
-  validate :has_valid_output
+  validate :valid_output?
 
   private
 
-  def has_valid_output
+  def valid_output?
     return unless output_format == 'json'
 
     begin

--- a/app/models/test_result.rb
+++ b/app/models/test_result.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 # == Schema Information
 #
 # Table name: test_results
@@ -14,6 +13,7 @@
 #  build_server_id  :integer
 #  semver_string    :string
 #  output           :text
+#  output_format    :string           default("text"), not null
 #
 # Indexes
 #
@@ -27,7 +27,24 @@
 #
 
 class TestResult < ApplicationRecord
+  VALID_OUTPUT_FORMATS = %w[json text]
+
   belongs_to :addon_version
   belongs_to :build_server
   has_many :ember_version_compatibilities
+
+  validates :output_format, inclusion: { in: VALID_OUTPUT_FORMATS }
+  validate :has_valid_output
+
+  private
+
+  def has_valid_output
+    return unless output_format == 'json'
+
+    begin
+      JSON.parse(output)
+    rescue JSON::ParserError
+      errors.add(:output, 'must be valid JSON')
+    end
+  end
 end

--- a/app/resources/api/v2/test_result_resource.rb
+++ b/app/resources/api/v2/test_result_resource.rb
@@ -2,7 +2,7 @@
 
 class API::V2::TestResultResource < JSONAPI::Resource
   immutable
-  attributes :succeeded, :status_message, :created_at, :semver_string, :canary, :output
+  attributes :succeeded, :status_message, :created_at, :semver_string, :canary, :output, :output_format
   has_one :version, class_name: 'Version', relation_name: 'addon_version', foreign_key: 'addon_version_id'
   has_many :ember_version_compatibilities
 

--- a/db/migrate/20190526121432_add_output_format_to_test_results.rb
+++ b/db/migrate/20190526121432_add_output_format_to_test_results.rb
@@ -1,0 +1,5 @@
+class AddOutputFormatToTestResults < ActiveRecord::Migration[5.1]
+  def change
+    add_column :test_results, :output_format, :string, null: false, default: 'text'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190311041851) do
+ActiveRecord::Schema.define(version: 20190526121432) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -261,6 +261,7 @@ ActiveRecord::Schema.define(version: 20190311041851) do
     t.integer "build_server_id"
     t.string "semver_string"
     t.text "output"
+    t.string "output_format", default: "text", null: false
     t.index ["addon_version_id"], name: "index_test_results_on_addon_version_id"
     t.index ["build_server_id"], name: "index_test_results_on_build_server_id"
   end

--- a/test/factories/test_results.rb
+++ b/test/factories/test_results.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 # == Schema Information
 #
 # Table name: test_results
@@ -14,6 +13,7 @@
 #  build_server_id  :integer
 #  semver_string    :string
 #  output           :text
+#  output_format    :string           default("text"), not null
 #
 # Indexes
 #

--- a/test/factories/test_results.rb
+++ b/test/factories/test_results.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: test_results

--- a/test/integration/api/v2/test_result_test.rb
+++ b/test/integration/api/v2/test_result_test.rb
@@ -10,6 +10,7 @@ class API::V2::ReviewTest < IntegrationTest
     semver-string
     canary
     output
+    output-format
   ].freeze
 
   TEST_RESULT_RELATIONSHIPS = %w[

--- a/test/models/test_result_test.rb
+++ b/test/models/test_result_test.rb
@@ -1,0 +1,64 @@
+# == Schema Information
+#
+# Table name: test_results
+#
+#  id               :integer          not null, primary key
+#  addon_version_id :integer
+#  succeeded        :boolean
+#  status_message   :string
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  canary           :boolean          default(FALSE), not null
+#  build_server_id  :integer
+#  semver_string    :string
+#  output           :text
+#  output_format    :string           default("text"), not null
+#
+# Indexes
+#
+#  index_test_results_on_addon_version_id  (addon_version_id)
+#  index_test_results_on_build_server_id   (build_server_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (addon_version_id => addon_versions.id)
+#  fk_rails_...  (build_server_id => build_servers.id)
+#
+
+require 'test_helper'
+
+class TestResultTest < ActiveSupport::TestCase
+  test 'only accepts valid values for output_format' do
+    addon_version = create(:addon_version)
+    build_server = create(:build_server)
+    valid_formats = %w(json text)
+    some_invalid_formats = %w(binary foo)
+
+    valid_formats.each do |format|
+      test_result = TestResult.new(output_format: format, output: '{}', addon_version: addon_version, build_server: build_server)
+      assert test_result.valid?
+    end
+
+    some_invalid_formats.each do |format|
+      test_result = TestResult.new(output_format: format, output: '{}', addon_version: addon_version, build_server: build_server)
+      assert !test_result.valid?
+    end
+  end
+
+  test 'when output_format is "json", output must be valid JSON' do
+    invalid_json = "{foo: 'bar' BAZ}"
+
+    addon_version = create(:addon_version)
+    build_server = create(:build_server)
+
+    test_result = TestResult.new(
+      addon_version: addon_version,
+      build_server: build_server,
+      output: invalid_json,
+      output_format: 'json'
+    )
+
+    assert !test_result.valid?
+    assert_equal 'must be valid JSON', test_result.errors[:output].first
+  end
+end

--- a/test/models/test_result_test.rb
+++ b/test/models/test_result_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: test_results
@@ -31,8 +33,8 @@ class TestResultTest < ActiveSupport::TestCase
   test 'only accepts valid values for output_format' do
     addon_version = create(:addon_version)
     build_server = create(:build_server)
-    valid_formats = %w(json text)
-    some_invalid_formats = %w(binary foo)
+    valid_formats = %w[json text]
+    some_invalid_formats = %w[binary foo]
 
     valid_formats.each do |format|
       test_result = TestResult.new(output_format: format, output: '{}', addon_version: addon_version, build_server: build_server)


### PR DESCRIPTION
This updates the server to accept & handle JSON-formatted data from the test runner (while preserving handling for the current bunch-of-text format). It also adds an `output_format` attribute to the TestResult resource so the frontend can tell what sort of data (plain text or stringified JSON) is in the `output` attr.