### PR TITLE
Change log level for production to 'warn' (instead of 'debug')

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -49,7 +49,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :warn
 
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]


### PR DESCRIPTION
We're generating a ton of logging that we don't need (nearly 50MB a day in plaintext & close to 2MB gzipped); this should cut down on that.