### PR TITLE
Save default semver string for builds

### DIFF
--- a/app/controllers/test_results_controller.rb
+++ b/app/controllers/test_results_controller.rb
@@ -34,7 +34,7 @@ class TestResultsController < ApplicationController
     end
 
     ActiveRecord::Base.transaction do
-      semver_string = build.addon_version.ember_version_compatibility
+      semver_string = build.semver_string
       if build.canary?
         semver_string = nil
       end

--- a/app/lib/build_queuer.rb
+++ b/app/lib/build_queuer.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class BuildQueuer
+  DEFAULT_EMBER_VERSION_COMPATIBILITY_STRING = '~3.4.0 || ~3.8.0 || ~3.12.0 || >=3.13.0'
+
+  attr_reader :addon_version
+
+  def initialize(addon_version)
+    @addon_version = addon_version
+  end
+
+  def queue
+    PendingBuild.create!(
+      addon_version: addon_version,
+      semver_string: addon_version.ember_version_compatibility || DEFAULT_EMBER_VERSION_COMPATIBILITY_STRING
+    )
+  end
+end

--- a/app/models/pending_build.rb
+++ b/app/models/pending_build.rb
@@ -11,6 +11,7 @@
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  canary            :boolean          default(FALSE), not null
+#  semver_string     :string
 #
 # Indexes
 #

--- a/app/serializers/pending_build_serializer.rb
+++ b/app/serializers/pending_build_serializer.rb
@@ -11,6 +11,7 @@
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  canary            :boolean          default(FALSE), not null
+#  semver_string     :string
 #
 # Indexes
 #

--- a/app/serializers/pending_build_serializer.rb
+++ b/app/serializers/pending_build_serializer.rb
@@ -25,8 +25,6 @@
 #
 
 class PendingBuildSerializer < ApplicationSerializer
-  DEFAULT_EMBER_VERSION_COMPATIBILITY_STRING = '~3.4.0 || ~3.8.0 || ~3.12.0 || >=3.13.0'
-
   attributes :id, :addon_name, :repository_url, :version, :canary, :ember_version_compatibility
 
   def addon_name
@@ -42,6 +40,6 @@ class PendingBuildSerializer < ApplicationSerializer
   end
 
   def ember_version_compatibility
-    object.addon_version.ember_version_compatibility || DEFAULT_EMBER_VERSION_COMPATIBILITY_STRING
+    object.semver_string
   end
 end

--- a/db/migrate/20200126220215_add_semver_string_to_pending_builds.rb
+++ b/db/migrate/20200126220215_add_semver_string_to_pending_builds.rb
@@ -1,0 +1,5 @@
+class AddSemverStringToPendingBuilds < ActiveRecord::Migration[5.1]
+  def change
+    add_column :pending_builds, :semver_string, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191220234215) do
+ActiveRecord::Schema.define(version: 20200126220215) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -256,6 +256,7 @@ ActiveRecord::Schema.define(version: 20191220234215) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "canary", default: false, null: false
+    t.string "semver_string"
     t.index ["addon_version_id"], name: "index_pending_builds_on_addon_version_id"
     t.index ["build_server_id"], name: "index_pending_builds_on_build_server_id"
   end

--- a/lib/tasks/tests.rake
+++ b/lib/tasks/tests.rake
@@ -14,6 +14,6 @@ namespace :tests do
     Addon.top_n(200).with_valid_repo
          .map(&:latest_addon_version)
          .select { |version| version.test_results.where(canary: false).count == 0 }
-         .each { |version| PendingBuild.create!(addon_version: version) }
+         .each { |version| BuildQueuer.new(version).queue }
   end
 end

--- a/test/controllers/build_queue_controller_test.rb
+++ b/test/controllers/build_queue_controller_test.rb
@@ -75,22 +75,13 @@ class BuildQueueControllerTest < ControllerTest
     assert_equal true, json_response['pending_build']['canary']
   end
 
-  test "includes the addon's reported Ember version compatibility string for tests, if present" do
-    ember_version_compatibility_string = '>= 2.0.0'
-    addon_version = create(:addon_version_with_ember_version_compatibility, ember_version_compatibility: ember_version_compatibility_string)
-    pending_build = create(:pending_build, addon_version: addon_version)
+  test "includes the build's semver string as ember_version_compatibility" do
+    ember_version_compatibility_string = '>= 3.16.0'
+    addon_version = create(:addon_version)
+    pending_build = create(:pending_build, addon_version: addon_version, semver_string: ember_version_compatibility_string)
 
     authed_post :get_build
 
     assert_equal ember_version_compatibility_string, json_response['pending_build']['ember_version_compatibility']
-  end
-
-  test 'includes default Ember version compatibility string for tests, if not specified for the addon version' do
-    addon_version = create(:addon_version)
-    create(:pending_build, addon_version: addon_version)
-
-    authed_post :get_build
-
-    assert_equal PendingBuildSerializer::DEFAULT_EMBER_VERSION_COMPATIBILITY_STRING, json_response['pending_build']['ember_version_compatibility']
   end
 end

--- a/test/controllers/test_results_controller_test.rb
+++ b/test/controllers/test_results_controller_test.rb
@@ -110,7 +110,7 @@ class TestResultsControllerTest < ControllerTest
 
   test 'saves the version compatibility string that was used, when there is one' do
     addon_version = create(:addon_version_with_ember_version_compatibility, ember_version_compatibility: '>= 2.0.0')
-    pending_build = create(:pending_build, addon_version: addon_version, build_server: build_server, build_assigned_at: 5.minutes.ago)
+    pending_build = create(:pending_build, addon_version: addon_version, build_server: build_server, build_assigned_at: 5.minutes.ago, semver_string: '>= 2.0.0')
     authed_post :create, pending_build_id: pending_build.id, status: 'succeeded', results: build_test_result_string(1)
 
     assert_equal '>= 2.0.0', TestResult.find_by(addon_version_id: pending_build.addon_version_id).semver_string
@@ -124,7 +124,7 @@ class TestResultsControllerTest < ControllerTest
 
   test 'does not save semver string for canary builds' do
     addon_version = create(:addon_version_with_ember_version_compatibility, ember_version_compatibility: '>= 2.0.0')
-    pending_build = create(:pending_build, addon_version: addon_version, build_server: build_server, build_assigned_at: 5.minutes.ago, canary: true)
+    pending_build = create(:pending_build, addon_version: addon_version, build_server: build_server, build_assigned_at: 5.minutes.ago, semver_string: '>= 2.0.0', canary: true)
     authed_post :create, pending_build_id: pending_build.id, status: 'succeeded', results: build_test_result_string(1)
 
     assert_nil TestResult.find_by(addon_version_id: pending_build.addon_version_id).semver_string

--- a/test/factories/pending_builds.rb
+++ b/test/factories/pending_builds.rb
@@ -11,6 +11,7 @@
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  canary            :boolean          default(FALSE), not null
+#  semver_string     :string
 #
 # Indexes
 #

--- a/test/lib/build_queuer_test.rb
+++ b/test/lib/build_queuer_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class BuildQueuerTest < ActiveSupport::TestCase
+  test 'when addon version has ember_version_compatibility, saves it as semver_string' do
+    addon_version = create(:addon_version_with_ember_version_compatibility, ember_version_compatibility: '>= 3.0')
+
+    create_queuer(addon_version).queue
+
+    assert_equal '>= 3.0', PendingBuild.last.semver_string
+  end
+
+  test 'when addon version does not have ember_version_compatibility, default value is saved as semver_string' do
+    addon_version = create(:addon_version)
+
+    create_queuer(addon_version).queue
+
+    assert_equal BuildQueuer::DEFAULT_EMBER_VERSION_COMPATIBILITY_STRING, PendingBuild.last.semver_string
+  end
+
+  private
+
+  def create_queuer(addon_version)
+    BuildQueuer.new(addon_version)
+  end
+end

--- a/test/models/pending_build_test.rb
+++ b/test/models/pending_build_test.rb
@@ -11,6 +11,7 @@
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  canary            :boolean          default(FALSE), not null
+#  semver_string     :string
 #
 # Indexes
 #


### PR DESCRIPTION
When we queue up new PendingBuilds, save the semver string to use (either the addon's reported Ember version compatibility, or a default). Then, when we record a TestResult from this build, save that value.

The current behavior is that if an addon doesn't provide a value for Ember version compatibility, we use a default value when running tests, but we don't save it anywhere. This leads to us showing a blank value in the UI:
<img width="588" alt="Screenshot 2020-01-27 08 36 09" src="https://user-images.githubusercontent.com/193435/73178865-21138200-40e0-11ea-8401-c83fbc1d5080.png">
