### PR TITLE
Remove the 'rendered_note' field from Addon model

### DIFF
--- a/app/models/addon.rb
+++ b/app/models/addon.rb
@@ -21,7 +21,6 @@
 #  github_user                  :string
 #  github_repo                  :string
 #  has_invalid_github_repo      :boolean          default(FALSE)
-#  rendered_note                :text
 #  last_month_downloads         :integer
 #  is_top_downloaded            :boolean          default(FALSE)
 #  is_top_starred               :boolean          default(FALSE)
@@ -54,7 +53,6 @@
 #  fk_rails_...  (latest_review_id => reviews.id)
 #
 
-# TODO: drop `rendered_note` once entirely on API v2
 class Addon < ApplicationRecord
   has_many :addon_versions, -> { order(released: :asc) }
   belongs_to :latest_addon_version, class_name: 'AddonVersion', optional: true

--- a/db/migrate/20210314150851_remove_rendered_note_from_addon.rb
+++ b/db/migrate/20210314150851_remove_rendered_note_from_addon.rb
@@ -1,0 +1,5 @@
+class RemoveRenderedNoteFromAddon < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :addons, :rendered_note, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200322112738) do
+ActiveRecord::Schema.define(version: 20210314150851) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -110,7 +110,6 @@ ActiveRecord::Schema.define(version: 20200322112738) do
     t.string "github_user"
     t.string "github_repo"
     t.boolean "has_invalid_github_repo", default: false
-    t.text "rendered_note"
     t.integer "last_month_downloads"
     t.boolean "is_top_downloaded", default: false
     t.boolean "is_top_starred", default: false

--- a/test/factories/addons.rb
+++ b/test/factories/addons.rb
@@ -21,7 +21,6 @@
 #  github_user                  :string
 #  github_repo                  :string
 #  has_invalid_github_repo      :boolean          default(FALSE)
-#  rendered_note                :text
 #  last_month_downloads         :integer
 #  is_top_downloaded            :boolean          default(FALSE)
 #  is_top_starred               :boolean          default(FALSE)

--- a/test/models/addon_test.rb
+++ b/test/models/addon_test.rb
@@ -21,7 +21,6 @@
 #  github_user                  :string
 #  github_repo                  :string
 #  has_invalid_github_repo      :boolean          default(FALSE)
-#  rendered_note                :text
 #  last_month_downloads         :integer
 #  is_top_downloaded            :boolean          default(FALSE)
 #  is_top_starred               :boolean          default(FALSE)


### PR DESCRIPTION
This field hasn't been used in a long while.