### PR TITLE
Filter which addon sizes are created

### DIFF
--- a/app/lib/npm_addon_data_updater.rb
+++ b/app/lib/npm_addon_data_updater.rb
@@ -108,12 +108,16 @@ class NpmAddonDataUpdater
         released: @metadata['time'][version],
         ember_cli_version: (data['devDependencies'] ? data['devDependencies']['ember-cli'] : nil)
       )
-      if ENV['ADDON_SIZES_ENABLED']
+      if ENV['ADDON_SIZES_ENABLED'] && should_calculate_size?
         PendingSizeCalculation.create!(addon_version: addon_version)
       end
       @addon.addon_versions << addon_version
       update_addon_version_dependencies(addon_version, data)
     end
+  end
+
+  def should_calculate_size?
+    @addon.scorable? && @addon.score >= 6
   end
 
   def update_latest_addon_version

--- a/lib/tasks/addons.rake
+++ b/lib/tasks/addons.rake
@@ -85,15 +85,15 @@ namespace :addons do
       ReadmeView.refresh
     end
 
-    desc 'Queue size data calculations for recently updated addons'
+    desc 'Queue size data calculations for top 1000 addons'
     task queue_asset_size_calculations: :environment do
-      latest_version_ids = Addon.active.where('latest_version_date > ?', 18.months.ago).pluck(:latest_addon_version_id)
-      latest_version_ids.each do |version_id|
+      addon_version_ids = Addon.top_n(1000).pluck(:latest_addon_version_id)
+      addon_version_ids.each do |version_id|
         if !AddonSize.exists?(addon_version_id: version_id) && !PendingSizeCalculation.exists?(addon_version_id: version_id)
           PendingSizeCalculation.create!(addon_version_id: version_id)
         end
       end
-      puts "Created PendingSizeCalculations for #{latest_version_ids.size} addon versions"
+      puts "Created PendingSizeCalculations for #{addon_version_ids.size} addon versions"
     end
 
     desc "Notify Dead Man's Snitch of completion"


### PR DESCRIPTION
- Update rake task with what we tend to actually run to generate addon sizes on production
- Skip addon size creation for addons that are wip, unreviewed, or score < 6