### PR TITLE
Update default Ember version compatibility string to reflect current LTS releases

### DIFF
--- a/app/serializers/pending_build_serializer.rb
+++ b/app/serializers/pending_build_serializer.rb
@@ -24,7 +24,7 @@
 #
 
 class PendingBuildSerializer < ApplicationSerializer
-  DEFAULT_EMBER_VERSION_COMPATIBILITY_STRING = '~3.16.0 || ~3.20.0 || ~3.24.0 || >=3.25.0'
+  DEFAULT_EMBER_VERSION_COMPATIBILITY_STRING = '~3.28.0 || ~4.4.0 || >=4.5.0'
 
   attributes :id, :addon_name, :repository_url, :version, :canary, :ember_version_compatibility
 


### PR DESCRIPTION
Update the default Ember version compatibility string (uses when we run addon tests for addons that don't define their own Ember version compatibility in `package.json`) so that it reflects current LTS releases and isn't testing older & no-longer-supported Ember versions.