### PR TITLE
move ember-observer lint rules to new plugin

### DIFF
--- a/app/lib/audit_updater.rb
+++ b/app/lib/audit_updater.rb
@@ -46,17 +46,17 @@ class AuditUpdater
 
   RULE_MAP = {
     'ember/no-jquery' => 'no-jquery',
-    'ember/no-jquery-integration' => 'no-jquery-integration',
     'ember/no-observers' => 'no-observers',
     'ember/no-new-mixins' => 'no-new-mixins',
     'ember/no-old-shims' => 'no-old-shims',
-    'ember/no-tracked' => 'no-tracked',
     'ember/no-classic-classes' => 'no-classic-classes',
     'ember/no-classic-components' => 'no-classic-components',
     'ember/no-computed-properties-in-native-classes' => 'no-computed-properties-in-native-classes',
     'ember/no-get' => 'no-get',
     'ember/no-get-with-default' => 'no-get-with-default',
-    'ember/no-ember-components' => 'no-ember-components',
-    'ember/no-glimmer-components' => 'no-glimmer-components'
+    'ember-observer/no-ember-components' => 'no-ember-components',
+    'ember-observer/no-glimmer-components' => 'no-glimmer-components',
+    'ember-observer/no-jquery-integration' => 'no-jquery-integration',
+    'ember-observer/no-tracked' => 'no-tracked'
   }.freeze
 end

--- a/linting/package.json
+++ b/linting/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "babel-eslint": "^10.0.3",
     "eslint": "^6.7.2",
-    "eslint-plugin-ember": "kategengler/eslint-plugin-ember#065cacd5b7b6fc5378f22b02fe49c53e10392d89"
+    "eslint-plugin-ember": "^10.5.0",
+    "eslint-plugin-ember-observer": "emberobserver/eslint-plugin-ember-observer#v1.0.0"
   }
 }

--- a/linting/static-eslintrc.js
+++ b/linting/static-eslintrc.js
@@ -9,24 +9,25 @@ module.exports = {
     }
   },
   plugins: [
-    'ember'
+    'ember',
+    'ember-observer'
   ],
   env: {
     browser: true
   },
   rules: {
     'ember/no-jquery': 'error',
-    'ember/no-jquery-integration': 'error',
     'ember/no-observers': 'error',
     'ember/no-new-mixins': 'error',
     'ember/no-old-shims': 'error',
-    'ember/no-tracked': 'error',
     'ember/no-classic-classes': 'error',
     'ember/no-classic-components': 'error',
     'ember/no-computed-properties-in-native-classes': 'error',
     'ember/no-get': 'error',
     'ember/no-get-with-default': 'error',
-    'ember/no-ember-components': 'error',
-    'ember/no-glimmer-components': 'error'
+    'ember-observer/no-ember-components': 'error',
+    'ember-observer/no-glimmer-components': 'error',
+    'ember-observer/no-jquery-integration': 'error',
+    'ember-observer/no-tracked': 'error',
   },
 };

--- a/linting/yarn.lock
+++ b/linting/yarn.lock
@@ -234,6 +234,14 @@ cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
+css-tree@^2.0.4:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-2.3.1.tgz#10264ce1e5442e8572fc82fbe490644ff54b5c20"
+  integrity sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==
+  dependencies:
+    mdn-data "2.0.30"
+    source-map-js "^1.0.1"
+
 debug@^4.0.1, debug@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
@@ -261,10 +269,10 @@ dot-case@^3.0.3:
     no-case "^3.0.3"
     tslib "^1.10.0"
 
-ember-rfc176-data@^0.3.12:
-  version "0.3.12"
-  resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.3.12.tgz#90d82878e69e2ac9a5438e8ce14d12c6031c5bd2"
-  integrity sha512-g9HeZj/gU5bfIIrGXkP7MhS2b3Vu5DfNUrYr14hy99TgIvtZETO+96QF4WOEUXGjIJdfTRjerVnQlqngPQSv1g==
+ember-rfc176-data@^0.3.15:
+  version "0.3.18"
+  resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.3.18.tgz#bb6fdcef49999981317ea81b6cc9210fb4108d65"
+  integrity sha512-JtuLoYGSjay1W3MQAxt3eINWXNYYQliK90tLwtb8aeCuQK8zKGCRbBodVIrkcTqshULMnRuTOS6t1P7oQk3g6Q==
 
 emoji-regex@^7.0.1:
   version "7.0.3"
@@ -281,12 +289,25 @@ escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
-eslint-plugin-ember@kategengler/eslint-plugin-ember#065cacd5b7b6fc5378f22b02fe49c53e10392d89:
-  version "7.8.1"
-  resolved "https://codeload.github.com/kategengler/eslint-plugin-ember/tar.gz/065cacd5b7b6fc5378f22b02fe49c53e10392d89"
+eslint-plugin-ember-observer@emberobserver/eslint-plugin-ember-observer#v1.0.0:
+  version "1.0.0"
+  resolved "https://codeload.github.com/emberobserver/eslint-plugin-ember-observer/tar.gz/a908a15b299cdec295988c9ed7edaf2e25e89255"
+  dependencies:
+    eslint-plugin-ember "^10.6.1"
+    requireindex "^1.2.0"
+
+eslint-plugin-ember@^10.5.0, eslint-plugin-ember@^10.6.1:
+  version "10.6.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-ember/-/eslint-plugin-ember-10.6.1.tgz#04ea84cc82307f64a2faa4f2855b30e5ebf9f722"
+  integrity sha512-R+TN3jwhYQ2ytZCA1VkfJDZSGgHFOHjsHU1DrBlRXYRepThe56PpuGxywAyDvQ7inhoAz3e6G6M60PzpvjzmNg==
   dependencies:
     "@ember-data/rfc395-data" "^0.0.4"
-    ember-rfc176-data "^0.3.12"
+    css-tree "^2.0.4"
+    ember-rfc176-data "^0.3.15"
+    eslint-utils "^3.0.0"
+    estraverse "^5.2.0"
+    lodash.kebabcase "^4.1.1"
+    requireindex "^1.2.0"
     snake-case "^3.0.3"
 
 eslint-scope@^5.0.0:
@@ -304,10 +325,22 @@ eslint-utils@^1.4.3:
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
+eslint-utils@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-3.0.0.tgz#8aebaface7345bb33559db0a1f13a1d2d48c3672"
+  integrity sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==
+  dependencies:
+    eslint-visitor-keys "^2.0.0"
+
 eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
   integrity sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
+
+eslint-visitor-keys@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
+  integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
 
 eslint@^6.7.2:
   version "6.7.2"
@@ -384,6 +417,11 @@ estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
+
+estraverse@^5.2.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
+  integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
 
 esutils@^2.0.2:
   version "2.0.3"
@@ -613,6 +651,11 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+lodash.kebabcase@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz#8489b1cb0d29ff88195cceca448ff6d6cc295c36"
+  integrity sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==
+
 lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
@@ -624,6 +667,11 @@ lower-case@^2.0.1:
   integrity sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==
   dependencies:
     tslib "^1.10.0"
+
+mdn-data@2.0.30:
+  version "2.0.30"
+  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.30.tgz#ce4df6f80af6cfbe218ecd5c552ba13c4dfa08cc"
+  integrity sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==
 
 mimic-fn@^2.1.0:
   version "2.1.0"
@@ -750,6 +798,11 @@ regexpp@^2.0.1:
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
   integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
 
+requireindex@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.2.0.tgz#3463cdb22ee151902635aa6c9535d4de9c2ef1ef"
+  integrity sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==
+
 resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
@@ -839,6 +892,11 @@ snake-case@^3.0.3:
   dependencies:
     dot-case "^3.0.3"
     tslib "^1.10.0"
+
+source-map-js@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
+  integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
 
 source-map@^0.5.0:
   version "0.5.7"

--- a/test/lib/audit_updater_test.rb
+++ b/test/lib/audit_updater_test.rb
@@ -106,7 +106,7 @@ class AuditUpdaterTest < ActiveSupport::TestCase
         'endLine' => 147, 'endColumn' => 9
       },
                  {
-                   'ruleId' => 'ember/no-jquery-integration',
+                   'ruleId' => 'ember-observer/no-jquery-integration',
                    'severity' => 2,
                    'message' => 'Do not use jQuery integration',
                    'line' => 147,
@@ -130,7 +130,7 @@ class AuditUpdaterTest < ActiveSupport::TestCase
           'endColumn' => 26
         },
         {
-          'ruleId' => 'ember/no-jquery-integration',
+          'ruleId' => 'ember-observer/no-jquery-integration',
           'severity' => 2,
           'message' => 'Do not use jQuery integration',
           'line' => 120,


### PR DESCRIPTION
I have created https://github.com/mansona/eslint-plugin-ember-observer which extracts the rules that are added in the https://github.com/kategengler/eslint-plugin-ember/tree/emberobserver fork/branch into their own plugin

If we think this is ok then I think we could/should transfer this plugin into the emberobserver org before merging this and then I'll update the package.json and re-run yarn 