### PR TITLE
Update download script to be more modern.

### DIFF
--- a/lib/tasks/npm.rake
+++ b/lib/tasks/npm.rake
@@ -4,7 +4,7 @@ require 'net/http'
 
 namespace :npm do
   task fetch_downloads: :environment do
-    addon_names = Addon.pluck(:name)
+    addon_names = Addon.not_hidden.pluck(:name)
     File.open('/tmp/addon-names.json', 'w') do |file|
       file << addon_names.to_json
     end

--- a/npm-fetch/historical-downloads.js
+++ b/npm-fetch/historical-downloads.js
@@ -1,84 +1,113 @@
-var RSVP = require('rsvp');
-var Registry = require('npm-registry');
-var async = require('async');
-var fs = require('fs');
-
-var eachLimit = RSVP.denodeify(async.eachLimit);
-var npm = new Registry({
-  registry: 'http://registry.npmjs.org'
-});
+const https = require('https');
+const fs = require('fs').promises;
 
 const MAX_RETRIES = 5;
-const MAX_CONCURRENCY = 5;
+const RETRY_DELAY_MS = 1000;
 
-function promiseEachLimit(array, limit, workFunction) {
-  let results = [ ];
-  return eachLimit(array, limit, (value, cb) => {
-    workFunction(value)
-      .then((result) => results.push({ state: 'fulfilled', value: result }))
-      .catch((err) => results.push({ state: 'rejected', reason: err, inputValue: value }))
-      .finally(() => cb());
-  })
-  .then(() => RSVP.resolve(results));
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-function requestWithRetries(resolve, reject, endpoint, method, args, successCallback, attempts)
-{
-	var registryCallback = function(err, data) {
-		if (err) {
-			if (attempts >= MAX_RETRIES) {
-				reject(err);
-			} else {
-				requestWithRetries(resolve, reject, endpoint, method, args, successCallback, attempts + 1);
-			}
-		} else {
-			if (data && data[0] && data[0].error === 'proxy_error') {
-				if (attempts >= MAX_RETRIES) {
-					reject(data[0]);
-				} else {
-					requestWithRetries(resolve, reject, endpoint, method, args, successCallback, attempts + 1);
-				}
-			} else {
-				resolve(successCallback(data));
-			}
-		}
-	};
-	var argsWithCallback = args.concat(registryCallback);
-	npm[endpoint][method].apply(npm[endpoint], argsWithCallback);
+function httpsGet(url) {
+  return new Promise((resolve, reject) => {
+    https.get(url, (res) => {
+      let data = '';
+      res.on('data', (chunk) => data += chunk);
+      res.on('end', () => resolve({
+        statusCode: res.statusCode,
+        data,
+        headers: res.headers
+      }));
+    }).on('error', reject);
+  });
 }
 
-function request(endpointAndMethod, args, successCallback)
-{
-	var pieces = endpointAndMethod.split('.');
-	var endpoint = pieces[0];
-	var method = pieces[1];
+async function fetchWithRetries(packageName, attempts = 0) {
+  const url = `https://api.npmjs.org/downloads/range/last-month/${packageName}`;
+  try {
+    console.log(`Fetching ${packageName}...`);
+    const { statusCode, data, headers } = await httpsGet(url);
 
-	if (typeof(args) !== 'object') {
-		args = [ args ];
-	}
+    if (statusCode === 200) {
+      return JSON.parse(data);
+    }
 
-	return new RSVP.Promise(function(resolve, reject) {
-		requestWithRetries(resolve, reject, endpoint, method, args, successCallback, 0);
-	});
+    if (statusCode === 404) {
+      return null;
+    }
+
+    if (statusCode === 429 || statusCode >= 500) {
+      if (attempts >= MAX_RETRIES) {
+        throw new Error(`HTTP ${statusCode} after ${MAX_RETRIES} retries fetching ${packageName}`);
+      }
+
+      let delay = RETRY_DELAY_MS * Math.pow(2, attempts);
+
+      if (headers['retry-after']) {
+        const retryAfter = headers['retry-after'];
+        console.log(`Retry-After header: ${retryAfter}`);
+
+        // Retry-After can be in seconds or a date
+        const retryAfterSeconds = parseInt(retryAfter);
+        if (!isNaN(retryAfterSeconds) && retryAfterSeconds > 0) {
+          delay = retryAfterSeconds * 1000;
+        } else {
+          const retryAfterDate = new Date(retryAfter);
+          if (!isNaN(retryAfterDate.getTime())) {
+            const calculatedDelay = retryAfterDate.getTime() - Date.now();
+            if (calculatedDelay > 0) {
+              delay = calculatedDelay;
+            }
+          }
+        }
+      }
+
+      console.log(`Rate limited or server error (${statusCode}), retrying ${packageName} in ${delay}ms...`);
+      await sleep(delay);
+      return fetchWithRetries(packageName, attempts + 1);
+    }
+
+    throw new Error(`HTTP ${statusCode}: ${data}`);
+  } catch (err) {
+    if (attempts >= MAX_RETRIES) {
+      throw err;
+    }
+    const delay = RETRY_DELAY_MS * Math.pow(2, attempts);
+    console.log(`Request error fetching ${packageName}, retrying in ${delay}ms...`);
+    await sleep(delay);
+    return fetchWithRetries(packageName, attempts + 1);
+  }
 }
 
-function downloads(packageName)
-{
-	return request('downloads.range', [ 'last-month', packageName ], function(data) {
-		return data[0];
-	});
+async function main() {
+  try {
+    const packageNamesData = await fs.readFile('/tmp/addon-names.json', 'utf8');
+    const packageNames = JSON.parse(packageNamesData);
+
+    const results = [];
+
+    for (const packageName of packageNames) {
+      try {
+        const data = await fetchWithRetries(packageName);
+        results.push({ status: 'fulfilled', value: data });
+      } catch (err) {
+        console.error('WARN: failed to get download data for', packageName);
+        console.error(err);
+        results.push({ status: 'rejected', reason: err });
+      }
+
+      await sleep(10);
+    }
+
+    const downloadData = results
+      .filter(result => result.status === 'fulfilled' && result.value !== null)
+      .map(result => result.value);
+
+    await fs.writeFile('/tmp/addon-downloads.json', JSON.stringify(downloadData));
+  } catch (err) {
+    console.error('Error:', err);
+    process.exit(1);
+  }
 }
 
-var packageNames = JSON.parse(fs.readFileSync('/tmp/addon-names.json'));
-promiseEachLimit(packageNames, MAX_CONCURRENCY, (packageName) => downloads(packageName))
-	.then(function(promises) {
-		promises.filter(p => p.state === 'rejected').map(p => p.inputValue).forEach(packageName => console.log('WARN: failed to get download data for', packageName));
-		let downloadData = promises.filter(p => p.state === 'fulfilled').map(p => p.value);
-		fs.writeFile("/tmp/addon-downloads.json", JSON.stringify(downloadData), function(err) {
-			if (err) {
-				console.log("Error writing output file:", err);
-			}
-		});
-	}).catch(function(err) {
-		console.log("Error:", err);
-	});
+main();


### PR DESCRIPTION
Retry-After header is always 0, but present, so just in case, handle it. Otherwise use backoff.

Limit download counts to unhidden addons

Deployed as a hotfix and it works.